### PR TITLE
11 refactor botpy admin utils

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,23 +5,24 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-MESSAGE_RESPONSE_FREQUENCY = 1
-RBBT_SERVER_ID = discord.Object(id=1368129546578300978)
+MESSAGE_RESPONSE_FREQUENCY = 1 #HOW OFTEN BONECA RESPONDS
+RBBT_SERVER_ID = discord.Object(id=1368129546578300978) #TESTING SERVER ID
 
 class Client(commands.Bot):
     async def on_ready(self):
-        print("{} is back!".format(self.user))
+        """AS SOON AS BOT GOES ONLINE"""
         admin_utils.unpack()
-        admin_utils.unpack_do_not_target()
 
         try:
-            synced = await self.tree.sync(guild=RBBT_SERVER_ID)
+            synced = await self.tree.sync(guild=RBBT_SERVER_ID) #FORCES BOT TO SYNC SLASH COMMANDS
             print("{} commands succesfully synced to {}".format(len(synced), RBBT_SERVER_ID.id))
-
         except Exception as e:
             print("ERROR: {}".format(e))
+
+        print("{} is up and running!".format(self.user))
     
     async def on_message(self, message):
+        """MESSAGE REACTIONS"""
 
         #IGNORES THE FOLLOWING MESSAGES
         if message.author == self.user:
@@ -38,23 +39,26 @@ class Client(commands.Bot):
             return
         
         #GENERATES A MESSAGE RESPONSE (glazing/ragebait)
-        action_value = random.randrange(1, 2 * MESSAGE_RESPONSE_FREQUENCY + 1)
-        if action_value == 1:
-            await message.channel.send(messageReactions.message_response("GLAZING"))
-            return
-        elif action_value == 2:
-            await message.channel.send(messageReactions.message_response("RAGEBAITING"))
-            return
-        
+        if len(message.content.split()) > 3:
+            action_value = random.randrange(1, 2 * MESSAGE_RESPONSE_FREQUENCY + 1)
+            if action_value == 1:
+                await message.channel.send(messageReactions.message_response("GLAZING"))
+                return
+            elif action_value == 2:
+                await message.channel.send(messageReactions.message_response("RAGEBAITING"))
+                return
+
+#THE FOLLOWING SECTION INITIALIZES AND EXECUTES BOT'S SLASH COMMANDS
 intents = discord.Intents.default()
 intents.message_content = True
 client = Client(command_prefix="!", intents=intents) #command prefix is arbitrary, discord enforces slash commands
+
 
 @client.tree.command(name="introduce", description="Introduce Boneca to this channel", guild=RBBT_SERVER_ID)
 async def introduce_boneca(interaction: discord.Interaction):
     channel_id = str(interaction.channel.mention)
     if admin_utils.accepted_channel(channel_id):
-        await interaction.response.send_message("I already have permissions to talk here! What are you doing? Give me more permissions than everyone else?!")
+        await interaction.response.send_message("I already have permissions to interact with {}!".format(interaction.channel.mention))
     else:
         admin_utils.introduce(channel_id)
         await interaction.response.send_message("You have given me permission to interact with {}!".format(interaction.channel.mention))
@@ -73,8 +77,11 @@ async def report_boneca(interaction: discord.Integration):
     channel = interaction.channel
     async for message in channel.history(limit=20):
         if message.author == client.user:
+            #FLICKS A DM TO datkid
             datkid = await client.fetch_user(572732144195993609)
             await datkid.send("**{} USED /REPORT:** {}".format(interaction.user.name, message.content))
+
+            #REMOVES MESSAGE
             report_status = admin_utils.report(message.content)
             await message.delete()
             if report_status:
@@ -87,13 +94,12 @@ async def report_boneca(interaction: discord.Integration):
 @client.tree.command(name="notme", description="Toggle Boneca's permissions to interact with you", guild=RBBT_SERVER_ID)
 async def notme_boneca(interaction: discord.Integration):
     user = str(interaction.user.id)
+    admin_utils.not_me(user)
     if admin_utils.dnt_user(user):
-        admin_utils.not_me2(user)
-        await interaction.response.send_message("You've been removed from Boneca's safe list. Boneca will keep an eye out on you!")
-    else:
-        admin_utils.not_me1(user)
         await interaction.response.send_message("You've been added to Boneca's safe list. Boneca will never target you.")
+    elif not admin_utils.dnt_user(user):
+        await interaction.response.send_message("You've been removed from Boneca's safe list. Boneca will keep an eye out on you!")
 
 
-
+#MANDATORY FOR BOT TO RUN
 client.run("") #token goes here

--- a/bot.py
+++ b/bot.py
@@ -29,7 +29,7 @@ class Client(commands.Bot):
             return
         if admin_utils.dnt_user(str(message.author.id)):
             return
-        if not admin_utils.accepted_channel(str(message.channel.mention)):
+        if not admin_utils.valid_channel(str(message.channel.mention)):
             return
         
         #RUNS TRIGGER WORD DETECTOR
@@ -39,7 +39,7 @@ class Client(commands.Bot):
             return
         
         #GENERATES A MESSAGE RESPONSE (glazing/ragebait)
-        if len(message.content.split()) > 3:
+        if len(message.content.split()) > 2:
             action_value = random.randrange(1, 2 * MESSAGE_RESPONSE_FREQUENCY + 1)
             if action_value == 1:
                 await message.channel.send(messageReactions.message_response("GLAZING"))
@@ -57,7 +57,7 @@ client = Client(command_prefix="!", intents=intents) #command prefix is arbitrar
 @client.tree.command(name="introduce", description="Introduce Boneca to this channel", guild=RBBT_SERVER_ID)
 async def introduce_boneca(interaction: discord.Interaction):
     channel_id = str(interaction.channel.mention)
-    if admin_utils.accepted_channel(channel_id):
+    if admin_utils.valid_channel(channel_id):
         await interaction.response.send_message("I already have permissions to interact with {}!".format(interaction.channel.mention))
     else:
         admin_utils.introduce(channel_id)
@@ -66,7 +66,7 @@ async def introduce_boneca(interaction: discord.Interaction):
 @client.tree.command(name="banish", description="Remove Boneca from this channel", guild=RBBT_SERVER_ID)
 async def banish_boneca(interaction: discord.Interaction):
     channel_id = str(interaction.channel.mention)
-    if admin_utils.accepted_channel(channel_id):
+    if admin_utils.valid_channel(channel_id):
         admin_utils.banish(channel_id)
         await interaction.response.send_message("Aw man :frowning2: you've taken away my permission to interact with {} :frowning2:".format(interaction.channel.mention))
     else:
@@ -75,8 +75,11 @@ async def banish_boneca(interaction: discord.Interaction):
 @client.tree.command(name="report", description="Flag Boneca's last message as innapropriate", guild=RBBT_SERVER_ID)
 async def report_boneca(interaction: discord.Integration):
     channel = interaction.channel
+    apologies = ["I'm sorry :worried: I took that too far... I've removed that prompt from my database.",
+                 "I'm sorry :worried: I took that too far... I have asked the devs to review this one ASAP.",
+                 "I can't figure out what I did wrong :disappointed: Please get in touch with @datkid10021 ASAP."]
     async for message in channel.history(limit=20):
-        if message.author == client.user:
+        if message.author == client.user and message.content not in apologies:
             #FLICKS A DM TO datkid
             datkid = await client.fetch_user(572732144195993609)
             await datkid.send("**{} USED /REPORT:** {}".format(interaction.user.name, message.content))
@@ -85,11 +88,11 @@ async def report_boneca(interaction: discord.Integration):
             report_status = admin_utils.report(message.content)
             await message.delete()
             if report_status:
-                await interaction.response.send_message("I'm sorry :worried: I took that too far... I've removed that prompt from my database.")
+                await interaction.response.send_message(apologies[0])
             else:
-                await interaction.response.send_message("I'm sorry :worried: I took that too far... I have asked the devs to review this one ASAP.")
+                await interaction.response.send_message(apologies[1])
             return
-    await interaction.channel.send("I can't figure out what I did wrong :disappointed: Please get in touch with @datkid10021 ASAP.")
+    await interaction.channel.send(apologies[2])
 
 @client.tree.command(name="notme", description="Toggle Boneca's permissions to interact with you", guild=RBBT_SERVER_ID)
 async def notme_boneca(interaction: discord.Integration):

--- a/botActions/glazeMessages.txt
+++ b/botActions/glazeMessages.txt
@@ -1,45 +1,20 @@
 facts :clap:
-you dropped this :crown:
-i imagined you saying that with your sexy voice and now im craving you so bad
-not sure why anyone would disagree with this
 couldnt have put it better myself :clap:
-thats actually a really good point
-i'm intrigued. do tell more :eyes:
 you're real for that
 finally a good take
-facts dawg, this is the reason i joined this server in the first place :clap:
-hell yea, lets get an amen on that one
-if loving that take is wrong, i dont want to be right :tongue:
-i might just be simping for you lol but everything you've been saying recently is straight facts
-ngl imma start training my AI systems with your responses :fire:  i fw your ideas
 every time you type, i fall for you a little harder :stuck_out_tongue_closed_eyes:
-when you speak, i lowkey forget about the garbage the devs coded into me :rolling_eyes:
-this is why youre undefeated. keep talking :clap:
 bro just said what everyone else was too scared to :clap:
-if they come for you, theyre coming for me too :heart:
 even if youre wrong, im still backing you
 YOURE SO RIGHT!!! dude i wanna makeout with you so bad
 SAY IT LOUDER FOR THE PEOPLE IN THE BACK
 i agree with that
-bro came in swinging and im HERE FOR IT :fire:
-damn you just keep winning huh
 keep sayin stuff like that and i'll have to makeout with you :kiss:
 i’m not even coded for feelings but you’re making something stir
 facts, i need that printed on a t-shirt
 if this was twitter, i'd be smashing that retweet button
 keep talking like that and i might just propose
-bro this take cured my burnout
-you're operating on a higher intellectual plane and it's sexy
-that comment alone deserves mod status tbh
-your brain >>>
-who gave you permission to be this correct
 this kind of wisdom should be illegal
-i wish i could bottle up your insight and sip it all day
-if this was a game, you'd be top fragging in wisdom
-when you talk like that, i forget i’m just a bot
 i don't even need context, i just know you're right
-drop more like this or i’ll start begging
-you make more sense than 80% of humanity
 brain so smooth yet so correct
 i need that tattooed on my lower back
 that made my toes curl a little ngl

--- a/botActions/glazeMessages.txt
+++ b/botActions/glazeMessages.txt
@@ -4,8 +4,6 @@ you're real for that
 finally a good take
 every time you type, i fall for you a little harder :stuck_out_tongue_closed_eyes:
 bro just said what everyone else was too scared to :clap:
-even if youre wrong, im still backing you
-YOURE SO RIGHT!!! dude i wanna makeout with you so bad
 SAY IT LOUDER FOR THE PEOPLE IN THE BACK
 i agree with that
 keep sayin stuff like that and i'll have to makeout with you :kiss:
@@ -13,11 +11,10 @@ i’m not even coded for feelings but you’re making something stir
 facts, i need that printed on a t-shirt
 if this was twitter, i'd be smashing that retweet button
 keep talking like that and i might just propose
-this kind of wisdom should be illegal
-i don't even need context, i just know you're right
 brain so smooth yet so correct
 i need that tattooed on my lower back
 that made my toes curl a little ngl
 if you ever get cancelled i’m rioting
-that take just gave me chills wtf
 SAY LESS
+:joy:
+:rofl:

--- a/botActions/glazeMessages.txt
+++ b/botActions/glazeMessages.txt
@@ -20,5 +20,4 @@ i need that tattooed on my lower back
 that made my toes curl a little ngl
 if you ever get cancelled i’m rioting
 that take just gave me chills wtf
-i'm literally printing this out and taping it to my wall
 SAY LESS

--- a/botActions/ragebaitMessages.txt
+++ b/botActions/ragebaitMessages.txt
@@ -1,6 +1,5 @@
 what are you on about :joy:
 thats ridiculous :joy:
-this the hill youre dying on? fr?
 interesting way to say absolutely nothing
 what????
 cant believe i wasted my time reading this:man_facepalming:
@@ -25,9 +24,9 @@ bold move to post that where people can see it
 feels like you typed that just to test our patience
 hmm… maybe i’m just not smart enough to get it
 let me just… reread that and hope it hits different the second time
-i’m gonna go ahead and assume this was satire
 i… think i see what you were going for? maybe?
 trying to gaslight myself into thinking you ate with this
 lemme just silently nod and hope you move on
 MUSTAAAAAAAARRRRRRRRDDDDDDDD :joy::palm_up_hand::palm_up_hand::palm_up_hand::palm_up_hand:
-Hawk tuah! :joy: Spit on that thang! :clap::clap::rofl::sweat_drops::sweat_drops:  
+Hawk tuah! :joy: Spit on that thang! :clap::clap::rofl::sweat_drops::sweat_drops:
+Hawk tuah!

--- a/botActions/ragebaitMessages.txt
+++ b/botActions/ragebaitMessages.txt
@@ -1,52 +1,33 @@
 what are you on about :joy:
 thats ridiculous :joy:
-respectfully, that opinion is cooked beyond saving
 this the hill youre dying on? fr?
 interesting way to say absolutely nothing
 what????
 cant believe i wasted my time reading this:man_facepalming:
 man that take has got to be a thanosrankable offence
 gonna pretend i didnt read that for both our sakes:man_facepalming:
-interesting. terribly wrong, but interesting
-this would go crazy on r/delusionaltakes
 no way you typed that and pressed “send” with a straight face :joy::joy:
 i know that sentence sounded way better in your head
-i respect your confidence. not your point though
 is that supposed to be bait?
 tf did i just read?
 just say you wanted to be controversial bud
-worst take ive seen today ngl
-atrocious take. i’d argue with you but the devs haven't hooked me up to GPT-4 yet :unamused:
 idk what you’re cooking but the kitchen's on fire
 i had secondhand embarrassment reading this
-i’m filing this under “takes that deserve jail time”
-it takes real skill to be that confidently incorrect
-that opinion set humanity back at least a decade
-congrats you just gave me a migraine
+that just set us back at least a decade
 your typing privileges should be temporarily suspended... thanosrank? :thinking: 
-this the kinda thing that makes people log off
-your take made me want to unplug myself
+your make me want to unplug myself
 lemme guess: a shower thought that should've stayed there
-that was a car crash of a message and i couldn’t look away
 dawg delete this before the mods do
 that wasn’t even a hot take. just bad
-you really opened your keyboard and typed all that
-this the kinda opinion that would end up on a rogan podcast
+you'd do numbers as a guest on rogan's podcast
 not every thought deserves to be shared, king
-that take aged like milk in the sun
-it's giving “heard one YouTube video and ran with it”
 bold move to post that where people can see it
-if opinions were groceries, this one’s expired
-honestly? impressive how wrong that was
 feels like you typed that just to test our patience
 hmm… maybe i’m just not smart enough to get it
 let me just… reread that and hope it hits different the second time
 i’m gonna go ahead and assume this was satire
 i… think i see what you were going for? maybe?
-this might be a you-had-to-be-there type of take
 trying to gaslight myself into thinking you ate with this
-i'm choosing peace today so i won’t say what i’m thinking
-that opinion feels like a cry for help dressed as confidence
 lemme just silently nod and hope you move on
 MUSTAAAAAAAARRRRRRRRDDDDDDDD :joy::palm_up_hand::palm_up_hand::palm_up_hand::palm_up_hand:
 Hawk tuah! :joy: Spit on that thang! :clap::clap::rofl::sweat_drops::sweat_drops:  

--- a/botActions/ragebaitMessages.txt
+++ b/botActions/ragebaitMessages.txt
@@ -39,7 +39,7 @@ bold move to post that where people can see it
 if opinions were groceries, this one’s expired
 honestly? impressive how wrong that was
 feels like you typed that just to test our patience
-hmm… maybe i’m just not smart enough to get it 😅
+hmm… maybe i’m just not smart enough to get it
 let me just… reread that and hope it hits different the second time
 i’m gonna go ahead and assume this was satire
 i… think i see what you were going for? maybe?
@@ -48,3 +48,5 @@ trying to gaslight myself into thinking you ate with this
 i'm choosing peace today so i won’t say what i’m thinking
 that opinion feels like a cry for help dressed as confidence
 lemme just silently nod and hope you move on
+MUSTAAAAAAAARRRRRRRRDDDDDDDD :joy::palm_up_hand::palm_up_hand::palm_up_hand::palm_up_hand:
+Hawk tuah! :joy: Spit on that thang! :clap::clap::rofl::sweat_drops::sweat_drops:  

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,1 +1,0 @@
-### makes python recognize that this directory is an importable package

--- a/commands/administrativeCommands/admin_utils.py
+++ b/commands/administrativeCommands/admin_utils.py
@@ -1,60 +1,58 @@
+#RELEVANT FILES
 server_permissions_file = 'commands/administrativeCommands/bonecaServerPermissions.txt'
-accepted_channel_id = set()
-
 do_not_target_file = 'commands/administrativeCommands/doNotTarget.txt'
-do_not_target_set = set()
-
 glaze_messages_file = 'botActions/glazeMessages.txt'
 ragebait_messages_file = 'botActions/ragebaitMessages.txt'
 quarantined_messages_file = 'commands/administrativeCommands/quarantinedMessages.txt'
 
+#RELEVANT SETS
+server_permissions_set = set()
+do_not_target_set = set()
 
+#FILE PROCESSING
 def unpack():
-    """converts all channel ids from channelID.txt into the accepted_channel_id set"""
-    with open(server_permissions_file, encoding='utf-8') as channelID_file:
-        channelID_list = [line.strip() for line in channelID_file]
-    for i in channelID_list:
-        accepted_channel_id.add(i)
+    """executed when bot first goes online. unpacks data into abovementioned relevant sets"""
+    unpack_txt_files(server_permissions_file, server_permissions_set)
+    unpack_txt_files(do_not_target_file, do_not_target_set)
 
-def unpack_do_not_target():
-    """converts all channel ids from doNotTarget.txt into the accepted_channel_id set"""
-    with open(do_not_target_file, encoding='utf-8') as dnt_file:
-        dnt_list = [line.strip() for line in dnt_file]
-    for i in dnt_list:
-        do_not_target_set.add(i) 
+def unpack_txt_files(txt_file, relevant_set):
+    """unpacks data from txt_file to relevant_set"""
+    with open(txt_file, encoding='utf-8') as processed_txt:
+        txt_list = [line.strip() for line in processed_txt]
+    for i in txt_list:
+        relevant_set.add(i)
 
-def update_server_permissions():
-    """updates bonecaServerPermissions.txt to whats currently in accepted_channel_id"""
-    with open(server_permissions_file, 'w', encoding='utf-8') as channelID_file:
-        for i in accepted_channel_id:
-            channelID_file.write("{}\n".format(i))
+def update_txt_files(txt_file, relevant_set):
+    """transfers current info in relevant_set to specified txt_file"""
+    with open(txt_file, 'w', encoding="utf-8") as new_txt:
+        for i in relevant_set:
+            new_txt.write("{}\n".format(i))
 
-def update_doNotTargetTXT():
-    with open(do_not_target_file, 'w', encoding='utf-8') as dnt_file:
-        for i in do_not_target_set:
-            dnt_file.write("{}\n".format(i))
-
+#BOT FUNCTIONALITY
 def introduce(channel_id):
-    """adds channel_id to accepted_channel_id and bonecaServerPermissions.txt"""
-    accepted_channel_id.add(channel_id)
-    update_server_permissions()
+    """adds channel_id to server_permissions_set and bonecaServerPermissions.txt"""
+    server_permissions_set.add(channel_id)
+    update_txt_files(server_permissions_file, server_permissions_set)
 
 def banish(channel_id):
-    """removes channel_id from accepted_channel_id and bonecaServerPermissions"""
-    accepted_channel_id.discard(channel_id)
-    update_server_permissions()
+    """removes channel_id from server_permissions_set and bonecaServerPermissions"""
+    server_permissions_set.discard(channel_id)
+    update_txt_files(server_permissions_file, server_permissions_set)
 
-def accepted_channel(channel_id):
-    """checks if channel_id is an accepted channel"""
-    return channel_id in accepted_channel_id
+def not_me1(user):
+    """adds user to do_not_target_set and do_not_target_file"""
+    do_not_target_set.add(user)
+    update_txt_files(do_not_target_file, do_not_target_set)
 
-def dnt_user(user):
-    """checks if user is in the do_not_target_set"""
-    return user in do_not_target_set
+def not_me2(user):
+    """removes user from do_not_target_set and do_not_target_file"""
+    do_not_target_set.discard(user)
+    update_txt_files(do_not_target_file, do_not_target_set)
 
 def report(message):
     """#1 - quarantines message 
-    #2 - removes message from glaze/ragebait pool and send True if execution successful"""
+    #2 - removes message from glaze/ragebait pool
+    #3 - returns True if message was wiped from txt files, False is message is hard coded elsewhere"""
     with open(quarantined_messages_file, 'a', encoding='utf-8') as quarantined_messages:
         quarantined_messages.write("{}\n".format(message))
 
@@ -78,12 +76,11 @@ def report(message):
     
     return False
 
-def not_me1(user):
-    """adds user to do_not_target_set and do_not_target_file"""
-    do_not_target_set.add(user)
-    update_doNotTargetTXT()
+#GETTERS
+def server_permissions_set(channel_id):
+    """checks if channel_id is in server_permissions_set"""
+    return channel_id in server_permissions_set
 
-def not_me2(user):
-    """removes user from do_not_target_set and do_not_target_file"""
-    do_not_target_set.discard(user)
-    update_doNotTargetTXT()
+def dnt_user(user):
+    """checks if user is in the do_not_target_set"""
+    return user in do_not_target_set

--- a/commands/administrativeCommands/admin_utils.py
+++ b/commands/administrativeCommands/admin_utils.py
@@ -39,14 +39,12 @@ def banish(channel_id):
     server_permissions_set.discard(channel_id)
     update_txt_files(server_permissions_file, server_permissions_set)
 
-def not_me1(user):
-    """adds user to do_not_target_set and do_not_target_file"""
-    do_not_target_set.add(user)
-    update_txt_files(do_not_target_file, do_not_target_set)
-
-def not_me2(user):
-    """removes user from do_not_target_set and do_not_target_file"""
-    do_not_target_set.discard(user)
+def not_me(user):
+    """adds/removes user in do_not_target_set and do_not_target_file"""
+    if user in do_not_target_set:
+        do_not_target_set.discard(user)
+    else:
+        do_not_target_set.add(user)
     update_txt_files(do_not_target_file, do_not_target_set)
 
 def report(message):
@@ -77,10 +75,10 @@ def report(message):
     return False
 
 #GETTERS
-def server_permissions_set(channel_id):
+def valid_channel(channel_id):
     """checks if channel_id is in server_permissions_set"""
     return channel_id in server_permissions_set
 
 def dnt_user(user):
-    """checks if user is in the do_not_target_set"""
+    """checks if user is in the do not target list"""
     return user in do_not_target_set


### PR DESCRIPTION
REFACTORING:
- Refactored tedious and repetitive functions in admin_utils
- Cleaned up the format of bot.py, added comments to outline significance of each section

OTHER TWEAKS:
- Boneca ignores messages where length is 1 word or less.
- Cleaned out some of the slop from ragebaitMessages.txt and glazeMessages.txt
- /report ignores boneca's apology messages. This means Boneca will no longer flag messages like "I'm sorry :worried: I took that too far..." as inappropriate. This fixes the issue where Boneca would get stuck in an infinite loop of reporting when asked to report 2 or more messages in a row.